### PR TITLE
Add manual window.close call

### DIFF
--- a/src/App/Search.tsx
+++ b/src/App/Search.tsx
@@ -55,6 +55,9 @@ const Search = () => {
           if (searchResults.length > 0) {
             const win = window.open(searchResults[0].link, '_blank');
             win?.focus();
+            
+            // Firefox doesn't automatically close the popup, so we need to close it manually
+            window.close();
           }
         }}
       >


### PR DESCRIPTION
Firefox doesn't automatically close the popup once you press enter (although Chrome does), so it stays open as you navigate to the new page.

A quick `window.close()` at the end of the form submit handler takes care of this, and doesn't have any negative impact in Chrome (have tested it).